### PR TITLE
Windows判別フラグを初回のみ環境チェックして変数で管理

### DIFF
--- a/path/dir_path.go
+++ b/path/dir_path.go
@@ -20,7 +20,7 @@ func DirPath(src string) string {
 }
 
 func pattern() string {
-	if util.IsWindows() {
+	if util.IsWindows {
 		return `^(\w:|\.{0,2}/)`
 	}
 	return `^\.{0,2}/`

--- a/terminal/clear.go
+++ b/terminal/clear.go
@@ -16,7 +16,7 @@ func Clear() error {
 
 // OS依存のターミナルクリアのコマンド
 func clearCmd() *exec.Cmd {
-	if util.IsWindows() {
+	if util.IsWindows {
 		return exec.Command("cmd", "/c", "cls")
 	}
 	return exec.Command("clear")

--- a/util/os.go
+++ b/util/os.go
@@ -2,7 +2,11 @@ package util
 
 import "runtime"
 
-// IsWindows は実行環境がWindowsであるかどうかを返す
-func IsWindows() bool {
-	return runtime.GOOS == "windows"
+var (
+	// IsWindows は実行環境がWindowsであるかどうかを返す、テスト時は値を後で設定可能
+	IsWindows = false
+)
+
+func init() {
+	IsWindows = runtime.GOOS == "windows"
 }


### PR DESCRIPTION
- 実行環境は途中で変わることがないので
- テスト時に後から設定して環境に依らず他環境のテストができる