### PR TITLE
codecovのレンジをデフォルトに戻した

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,7 +4,7 @@ codecov:
 coverage:
   precision: 2
   round: down
-  range: "60...90"
+  range: "70...100"
 
 parsers:
   gcov:


### PR DESCRIPTION
9割切っても色が変わらないのはさすがに見づらかったので