### PR TITLE
#48 recursive 付けたときのディレクトリ検索のパフォーマンス改善

### DIFF
--- a/file/dir.go
+++ b/file/dir.go
@@ -1,11 +1,10 @@
 package file
 
 import (
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/meian/gowatch/path"
 )
 
 // TargetDirs は監視対象のディレクトリ一覧を返す、recursiveを指定する場合はサブディレクトリを含む
@@ -28,10 +27,8 @@ func RecurseDir(dirPath string) ([]string, error) {
 	if !st.IsDir() {
 		return nil, NoDirError{Path: dirPath}
 	}
-	bucket := &dirBucket{paths: make([]string, 0)}
-	err = filepath.Walk(dirPath, bucket.walk)
-	if err != nil {
-		// 再帰関数内はエラーを返さないけどそもそもディレクトリが読めなかった対策
+	bucket := &dirBucket{paths: []string{}}
+	if err := bucket.collect(dirPath); err != nil {
 		return nil, err
 	}
 	return bucket.paths, nil
@@ -42,26 +39,35 @@ type dirBucket struct {
 	paths []string
 }
 
-// walk内で見つかったディレクトリパスを格納する
-func (bucket *dirBucket) walk(name string, file os.FileInfo, err error) error {
-	name = path.UnixPath(name)
-	if containsStartWithDot(name) {
-		return nil
+// ディレクトリパスを再帰的に収集する
+func (bucket *dirBucket) collect(dirPath string) error {
+	bucket.paths = append(bucket.paths, dirPath)
+	fs, err := ioutil.ReadDir(dirPath)
+	if err != nil {
+		return err
 	}
-	if file.IsDir() {
-		bucket.paths = append(bucket.paths, name)
+	for _, f := range fs {
+		if !f.IsDir() {
+			continue
+		}
+		name := f.Name()
+		if !targetDir(name) {
+			continue
+		}
+		bucket.collect(filepath.ToSlash(filepath.Join(dirPath, name)))
 	}
 	return nil
 }
 
-func containsStartWithDot(name string) bool {
-	for _, p := range strings.Split(name, "/") {
-		if p == "." || p == ".." {
-			continue
-		}
-		if strings.HasPrefix(p, ".") {
-			return true
-		}
+func targetDir(name string) bool {
+	switch {
+	case name == ".":
+		return true
+	case name == "..":
+		return true
+	case strings.HasPrefix(name, "."):
+		return false
+	default:
+		return true
 	}
-	return false
 }

--- a/file/dir_test.go
+++ b/file/dir_test.go
@@ -97,6 +97,58 @@ func TestTargetDirs(t *testing.T) {
 	}
 }
 
+func TestTargetDirsStatErr(t *testing.T) {
+	defer e.FSStatErr()()
+	testutil.ChCurrentDir()
+	type args struct {
+		dirPath   string
+		recursive bool
+	}
+	tests := []struct {
+		desc string
+		args args
+	}{
+		{desc: "directory - no recursive",
+			args: args{dirPath: "../testdata/dirtest", recursive: false}},
+		{desc: "directory - recursive",
+			args: args{dirPath: "../testdata/dirtest", recursive: true}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			a := assert.New(t)
+			_, err := file.TargetDirs(tt.args.dirPath, tt.args.recursive)
+			a.Error(err)
+		})
+	}
+}
+
+func TestTargetDirsReadDirErr(t *testing.T) {
+	defer e.FSReadDirErr()()
+	testutil.ChCurrentDir()
+	type args struct {
+		dirPath   string
+		recursive bool
+	}
+	tests := []struct {
+		desc    string
+		args    args
+		wantErr bool
+	}{
+		{desc: "directory - no recursive",
+			args: args{dirPath: "../testdata/dirtest", recursive: false}},
+		{desc: "directory - recursive",
+			args: args{dirPath: "../testdata/dirtest", recursive: true}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			a := assert.New(t)
+			got, err := file.TargetDirs(tt.args.dirPath, tt.args.recursive)
+			a.NoError(err)
+			a.NotNil(got)
+		})
+	}
+}
+
 func TestTargetDirPrivate(t *testing.T) {
 	testutil.ChCurrentDir()
 	tests := []struct {

--- a/file/dir_test.go
+++ b/file/dir_test.go
@@ -51,29 +51,6 @@ func TestRecurseSuccess(t *testing.T) {
 	}
 }
 
-func TestContainsStartWithDot(t *testing.T) {
-	testutil.ChCurrentDir()
-	tests := []struct {
-		desc     string
-		name     string
-		expected bool
-	}{
-		{desc: "no dot path", name: "foo/bar", expected: false},
-		{desc: "last path is dot started", name: "foo/.bar", expected: true},
-		{desc: "first path is dot started", name: ".foo/bar", expected: true},
-		{desc: "middle path is dot started", name: "foo/.bar/sub", expected: true},
-		{desc: "start path is curret", name: "./foo/bar", expected: false},
-		{desc: "start path is parent", name: "../foo/bar", expected: false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.desc, func(t *testing.T) {
-			a := assert.New(t)
-			actual := e.ContainsStartWithDot(tt.name)
-			a.Equal(tt.expected, actual)
-		})
-	}
-}
-
 func TestTargetDirs(t *testing.T) {
 	testutil.ChCurrentDir()
 	type args struct {
@@ -115,7 +92,30 @@ func TestTargetDirs(t *testing.T) {
 			a := assert.New(t)
 			got, err := file.TargetDirs(tt.args.dirPath, tt.args.recursive)
 			a.Equal(tt.wantErr, err != nil)
-			a.ElementsMatch(tt.want, got)
+			a.ElementsMatch(tt.want, got, got)
+		})
+	}
+}
+
+func TestTargetDirPrivate(t *testing.T) {
+	testutil.ChCurrentDir()
+	tests := []struct {
+		desc     string
+		name     string
+		expected bool
+	}{
+		{desc: "no dot name", name: "foo", expected: true},
+		{desc: "current dir", name: ".", expected: true},
+		{desc: "parent dir", name: "..", expected: true},
+		{desc: "start with dot name", name: ".foo", expected: false},
+		{desc: "contains dot name", name: "foo.bar", expected: true},
+		{desc: "end with dot name", name: "foo.", expected: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			a := assert.New(t)
+			actual := e.TargetDir(tt.name)
+			a.Equal(tt.expected, actual)
 		})
 	}
 }

--- a/file/export_test.go
+++ b/file/export_test.go
@@ -1,9 +1,45 @@
 package file
 
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
 type Exported struct{}
 
 var Export Exported
 
 func (e Exported) TargetDir(name string) bool {
 	return targetDir(name)
+}
+
+type fsStatErr struct {
+	fsImpl
+}
+
+func (f fsStatErr) Stat(name string) (os.FileInfo, error) {
+	return nil, errors.New(fmt.Sprint("Stat error: ", name))
+}
+func (e Exported) FSStatErr() func() {
+	return swapFS(fsStatErr{})
+}
+
+type fsReadDirErr struct {
+	fsImpl
+}
+
+func (f fsReadDirErr) ReadDir(dirname string) ([]os.FileInfo, error) {
+	return nil, errors.New(fmt.Sprint("ReadDir error: ", dirname))
+}
+func (e Exported) FSReadDirErr() func() {
+	return swapFS(fsReadDirErr{})
+}
+
+func swapFS(dummy fileSystem) func() {
+	tmp := fs
+	fs = dummy
+	return func() {
+		fs = tmp
+	}
 }

--- a/file/export_test.go
+++ b/file/export_test.go
@@ -4,6 +4,6 @@ type Exported struct{}
 
 var Export Exported
 
-func (e Exported) ContainsStartWithDot(name string) bool {
-	return containsStartWithDot(name)
+func (e Exported) TargetDir(name string) bool {
+	return targetDir(name)
 }


### PR DESCRIPTION
closes #48

walk使うと全ファイルシステムをスキャンするので代わりに `ioutil.ReadDir` で再帰処理をかけてディレクトリパスを収集するよう修正