### PR TITLE
テストのタイムアウトを延ばした

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
   test:
     name: Test
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 2
+    timeout-minutes: 5
     strategy:
       matrix:
         os: [ubuntu-18.04, windows-2019, macos-10.15]


### PR DESCRIPTION
2分だとmacがよくタイムアウト起こすので5分に変更