### PR TITLE
go testの追加引数を設定できるようにした

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -23,11 +23,6 @@ func init() {
 				Aliases: []string{"r"},
 				Usage:   "include subdirectories",
 			},
-			&cli.BoolFlag{
-				Name:    "verbose",
-				Aliases: []string{"v"},
-				Usage:   "show detail",
-			},
 		},
 		ArgsUsage: "[PATH]",
 		Action:    testAction,

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -10,6 +10,13 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+const (
+	testErrorConfig int = iota + 1
+	testErrorContext
+	testErrorWatcher
+	testErrorOnTest
+)
+
 // Test は変更監視とテストを実行するコマンド
 var Test *cli.Command
 
@@ -30,15 +37,18 @@ func init() {
 }
 
 func testAction(c *cli.Context) error {
-	config := test.NewConfig(c)
+	config, err := test.NewConfig(c)
+	if err != nil {
+		return cli.Exit(fmt.Errorf("cannot create config: %s", err), testErrorConfig)
+	}
 	nc, err := test.NewContext(config)
 	if err != nil {
 		log.Println(err)
-		return cli.Exit("cannot create context", 1)
+		return cli.Exit("cannot create context", testErrorContext)
 	}
 	nc.Watcher, err = newWatcher(nc)
 	if err != nil {
-		return cli.Exit("cannot create watcher", 2)
+		return cli.Exit("cannot create watcher", testErrorWatcher)
 	}
 
 	terminal.Clear()
@@ -49,7 +59,7 @@ func testAction(c *cli.Context) error {
 	go test.LoopTest(nc)
 	err = <-nc.Done
 	if err != nil {
-		return cli.Exit(err, 3)
+		return cli.Exit(err, testErrorOnTest)
 	}
 	return nil
 }

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -35,7 +35,7 @@ func init() {
 }
 
 func testAction(c *cli.Context) error {
-	config := test.GetConfig(c)
+	config := test.NewConfig(c)
 	nc, err := test.NewContext(config)
 	if err != nil {
 		log.Println(err)

--- a/cmd/test/config.go
+++ b/cmd/test/config.go
@@ -17,8 +17,8 @@ type Config struct {
 	Verbose bool
 }
 
-// GetConfig はコマンド実行情報から生成した設定値を返す
-func GetConfig(c *cli.Context) *Config {
+// NewConfig は設定情報を生成する
+func NewConfig(c *cli.Context) *Config {
 	return &Config{
 		Dir:       getDir(c),
 		Recursive: c.Bool("recursive"),

--- a/cmd/test/config.go
+++ b/cmd/test/config.go
@@ -1,8 +1,10 @@
 package test
 
 import (
-	"encoding/json"
+	"errors"
 	"fmt"
+	"path/filepath"
+	"strings"
 
 	"github.com/urfave/cli/v2"
 )
@@ -11,28 +13,44 @@ import (
 type Config struct {
 	// Dir は監視対象のディレクトリパス
 	Dir string
+	// Args は go test に渡す引数
+	Args []string
 	// Recursive はサブディレクトリを監視するかどうか
 	Recursive bool
 }
 
 // NewConfig は設定情報を生成する
-func NewConfig(c *cli.Context) *Config {
-	return &Config{
-		Dir:       getDir(c),
+func NewConfig(c *cli.Context) (*Config, error) {
+	config := &Config{
+		Args:      []string{},
 		Recursive: c.Bool("recursive"),
 	}
-}
-
-func getDir(c *cli.Context) string {
-	if path := c.Args().Get(0); path != "" {
-		return path
+	args := c.Args().Slice()
+	if len(args) == 0 {
+		config.Dir = "."
+		return config, nil
 	}
-	return "."
+	if !strings.HasPrefix(args[0], "-") {
+		config.Dir = strings.TrimRight(filepath.ToSlash(args[0]), "/")
+		args = args[1:]
+	} else {
+		config.Dir = "."
+	}
+	if len(args) > 0 && args[0] == "--" {
+		args = args[1:]
+	}
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] == "-run" {
+			return nil, errors.New("cannot use -run")
+		}
+	}
+	config.Args = args
+	return config, nil
 }
 
 // Show はコンフィグの情報を表示する
 func (c *Config) Show() {
-	println("Config:")
-	json, _ := json.MarshalIndent(c, "", "  ")
-	fmt.Println(string(json))
+	fmt.Println("directory:", c.Dir)
+	fmt.Println("recursive:", c.Recursive)
+	fmt.Println("arguments:", c.Args)
 }

--- a/cmd/test/config.go
+++ b/cmd/test/config.go
@@ -13,8 +13,6 @@ type Config struct {
 	Dir string
 	// Recursive はサブディレクトリを監視するかどうか
 	Recursive bool
-	// Verbose は詳細を表示するかどうか
-	Verbose bool
 }
 
 // NewConfig は設定情報を生成する
@@ -22,7 +20,6 @@ func NewConfig(c *cli.Context) *Config {
 	return &Config{
 		Dir:       getDir(c),
 		Recursive: c.Bool("recursive"),
-		Verbose:   c.Bool("verbose"),
 	}
 }
 

--- a/cmd/test/test.go
+++ b/cmd/test/test.go
@@ -65,9 +65,6 @@ func cmdArgs(c *Context, src string) ([]string, error) {
 		return nil, err
 	}
 	args := []string{"test", path.DirPath(src), "-run", pattern}
-	if c.Config.Verbose {
-		args = append(args, "-v")
-	}
 	return args, nil
 }
 

--- a/cmd/test/test.go
+++ b/cmd/test/test.go
@@ -64,7 +64,7 @@ func cmdArgs(c *Context, src string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	args := []string{"test", path.DirPath(src), "-run", pattern}
+	args := append([]string{"test", path.DirPath(src), "-run", pattern}, c.Config.Args...)
 	return args, nil
 }
 


### PR DESCRIPTION
- `gowatch test [path]` 以降の引数を go test に渡すようにした
  - `-run` 自体は内部で作るので渡せないようにしている
- `-v` は追加引数で渡せるのでコマンド引数からは削除した