### PR TITLE
#29 異なるパッケージを監視対象にする処理を追加

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -53,6 +53,7 @@ func testAction(c *cli.Context) error {
 
 	terminal.Clear()
 	config.Show()
+	fmt.Println("========================================")
 	fmt.Println("watch directories:", nc.Directories)
 
 	go test.LoopFSEvent(nc)

--- a/cmd/test/test.go
+++ b/cmd/test/test.go
@@ -64,7 +64,7 @@ func cmdArgs(c *Context, src string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	args := append([]string{"test", path.DirPath(src), "-run", pattern}, c.Config.Args...)
+	args := append([]string{"test", path.DirPath(src), "-run", pattern}, c.Args...)
 	return args, nil
 }
 


### PR DESCRIPTION
closes #29 

- フラグ以外で `-` で始まらない引数のリストはディレクトリとして扱う

```
gowatch test path1 path2
=> path1 と path2 はそれぞれパッケージパス

gowatch test path1 path2 -v
=> パッケージパス2つに go test のオプションとして -v を追加

gowatch test path1 path2 -- -cover
=> パス一覧後の -- は無視されて -cover のみが go test のオプションに渡される
```