### PR TITLE
Revert "#29 異なるパッケージを監視対象にする処理を追加"

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -53,7 +53,6 @@ func testAction(c *cli.Context) error {
 
 	terminal.Clear()
 	config.Show()
-	fmt.Println("========================================")
 	fmt.Println("watch directories:", nc.Directories)
 
 	go test.LoopFSEvent(nc)

--- a/cmd/test/config.go
+++ b/cmd/test/config.go
@@ -11,8 +11,8 @@ import (
 
 // Config はWatcherの設定を保持する
 type Config struct {
-	// Dirs は監視対象のディレクトリパス一覧
-	Dirs []string
+	// Dir は監視対象のディレクトリパス
+	Dir string
 	// Args は go test に渡す引数
 	Args []string
 	// Recursive はサブディレクトリを監視するかどうか
@@ -21,45 +21,36 @@ type Config struct {
 
 // NewConfig は設定情報を生成する
 func NewConfig(c *cli.Context) (*Config, error) {
-	dirs, args := parseArgs(c.Args().Slice())
-	correctDirs(dirs)
-	for _, arg := range args {
-		if arg == "-run" {
+	config := &Config{
+		Args:      []string{},
+		Recursive: c.Bool("recursive"),
+	}
+	args := c.Args().Slice()
+	if len(args) == 0 {
+		config.Dir = "."
+		return config, nil
+	}
+	if !strings.HasPrefix(args[0], "-") {
+		config.Dir = strings.TrimRight(filepath.ToSlash(args[0]), "/")
+		args = args[1:]
+	} else {
+		config.Dir = "."
+	}
+	if len(args) > 0 && args[0] == "--" {
+		args = args[1:]
+	}
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] == "-run" {
 			return nil, errors.New("cannot use -run")
 		}
 	}
-	return &Config{
-		Dirs:      dirs,
-		Args:      args,
-		Recursive: c.Bool("recursive"),
-	}, nil
-}
-
-func parseArgs(slice []string) (dirs []string, args []string) {
-	dirs = []string{"."}
-	if len(slice) == 0 {
-		return dirs, []string{}
-	}
-	for i, arg := range slice {
-		if strings.HasPrefix(arg, "-") {
-			dirs, slice = slice[0:i], slice[i:]
-			break
-		}
-	}
-	if len(slice) > 0 && slice[0] == "--" {
-		slice = slice[1:]
-	}
-	return dirs, slice
-}
-
-func correctDirs(dirs []string) {
-	for i, dir := range dirs {
-		dirs[i] = strings.TrimRight(filepath.ToSlash(dir), "/")
-	}
+	config.Args = args
+	return config, nil
 }
 
 // Show はコンフィグの情報を表示する
 func (c *Config) Show() {
-	fmt.Printf("directory: %v (recursive: %v)\n", c.Dirs, c.Recursive)
+	fmt.Println("directory:", c.Dir)
+	fmt.Println("recursive:", c.Recursive)
 	fmt.Println("arguments:", c.Args)
 }

--- a/cmd/test/context.go
+++ b/cmd/test/context.go
@@ -16,8 +16,8 @@ const (
 
 // Context はテスト実行時の情報を保持する
 type Context struct {
+	Config      *Config
 	Watcher     *notify.Watcher
-	Args        []string
 	Directories []string
 	Changed     *file.PairMap
 	State       int
@@ -27,33 +27,20 @@ type Context struct {
 
 // NewContext はコンフィグから実行情報を生成する
 func NewContext(config *Config) (*Context, error) {
-	dirs, err := collectDirs(config)
-	if err != nil {
-		return nil, err
+	c := &Context{
+		Config:  config,
+		Changed: file.NewPairMap(),
+		State:   None,
+		Done:    make(chan error),
 	}
-	return &Context{
-		Changed:     file.NewPairMap(),
-		State:       None,
-		Done:        make(chan error),
-		Args:        config.Args,
-		Directories: dirs,
-	}, nil
-}
-
-func collectDirs(config *Config) ([]string, error) {
-	dirs := []string{}
-	dirMap := map[string]bool{}
-	for _, dir := range config.Dirs {
-		tdirs, err := file.TargetDirs(dir, config.Recursive)
+	if config.Recursive {
+		dirs, err := file.RecurseDir(config.Dir)
 		if err != nil {
 			return nil, err
 		}
-		for _, tdir := range tdirs {
-			if _, ok := dirMap[tdir]; !ok {
-				dirs = append(dirs, tdir)
-				dirMap[tdir] = true
-			}
-		}
+		c.Directories = dirs
+	} else {
+		c.Directories = []string{config.Dir}
 	}
-	return dirs, nil
+	return c, nil
 }

--- a/cmd/test/test.go
+++ b/cmd/test/test.go
@@ -64,7 +64,7 @@ func cmdArgs(c *Context, src string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	args := append([]string{"test", path.DirPath(src), "-run", pattern}, c.Args...)
+	args := append([]string{"test", path.DirPath(src), "-run", pattern}, c.Config.Args...)
 	return args, nil
 }
 


### PR DESCRIPTION
Reverts meian/gowatch#68
なんか動作がおかしかったので戻す。
linuxコンテナ上で複数ターゲット指定するとフィルタが効かなくてカレントディレクトリが対象になる