### PR TITLE
GithubActionsのジョブを手動実行できるように #86

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,6 +14,8 @@ on:
       - go.sum
       - go.mod
       - codecov.yml
+  workflow_dispatch:
+    branches: ["*"]
 jobs:
   converage:
     name: Coverage

--- a/.github/workflows/reportCard.yml
+++ b/.github/workflows/reportCard.yml
@@ -8,6 +8,8 @@ on:
       - "**.go"
       - go.sum
       - go.mod
+  workflow_dispatch:
+    branches: ["master"]
 jobs:
   report:
     name: Report Card


### PR DESCRIPTION
- buildは適用済だった
- codecovは全てのブランチで適用
- reportCardはmasterのみ適用

=> 元のCI実行条件と同じ状態にした